### PR TITLE
Updated python version constraints for aif360

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About aif360
-============
+About aif360-feedstock
+======================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/aif360-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/Trusted-AI/AIF360
 
 Package license: Apache-2.0
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/aif360-feedstock/blob/main/LICENSE.txt)
 
 Summary: IBM AI Fairness 360
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - numpy >=1.16
     - pandas >=0.24.0
     - pip
-    - python >=3.6
+    - python >=3.7
     - scikit-learn >=0.22.1
     - scipy >=1.2.0,<1.6.0
     - tempeh
@@ -28,7 +28,7 @@ requirements:
     - matplotlib-base
     - numpy >=1.16
     - pandas >=0.24.0
-    - python >=3.6
+    - python >=3.7
     - scikit-learn >=0.22.1
     - scipy >=1.2.0,<1.6.0
     - tempeh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -20,7 +20,7 @@ requirements:
     - numpy >=1.16
     - pandas >=0.24.0
     - pip
-    - python >=3.6,<3.9
+    - python >=3.6
     - scikit-learn >=0.22.1
     - scipy >=1.2.0,<1.6.0
     - tempeh
@@ -28,7 +28,7 @@ requirements:
     - matplotlib-base
     - numpy >=1.16
     - pandas >=0.24.0
-    - python >=3.6,<3.9
+    - python >=3.6
     - scikit-learn >=0.22.1
     - scipy >=1.2.0,<1.6.0
     - tempeh


### PR DESCRIPTION
Hello,

I've made a minor modification to the Conda recipe for the `aif360` library. Here's a brief overview and justification for this change:

**Change Overview**:
- Updated the `python` requirement in `meta.yaml` from `>=3.6,<3.9` to `>=3.6`.

**Justification**:
- The `aif360` library on PyPI specifies its Python requirement as `>=3.7`, indicating its compatibility with Python versions 3.7 and above.
- Given the broader compatibility on PyPI, it seems beneficial for the Conda recipe to mirror this broader range, allowing users to employ the library in projects that use newer versions of Python.

I hope this change assists others who are looking to utilize `aif360` with newer Python versions via Conda.

Thank you for considering this pull request.

Best regards,
ZanMervic

